### PR TITLE
Add a way to customize method, headers, and payload on a feed

### DIFF
--- a/src/controllers/FeedsController.php
+++ b/src/controllers/FeedsController.php
@@ -424,6 +424,9 @@ class FeedsController extends Controller
         $feed->name = $request->getBodyParam('name', $feed->name);
         $feed->feedUrl = $request->getBodyParam('feedUrl', $feed->feedUrl);
         $feed->feedType = $request->getBodyParam('feedType', $feed->feedType);
+        $feed->feedMethod = $request->getBodyParam('feedMethod', $feed->feedMethod);
+        $feed->feedHeaders = $request->getBodyParam('feedHeaders', $feed->feedHeaders);
+        $feed->feedPayload = $request->getBodyParam('feedPayload', $feed->feedPayload);
         $feed->primaryElement = $request->getBodyParam('primaryElement', $feed->primaryElement);
         $feed->elementType = $request->getBodyParam('elementType', $feed->elementType);
         $feed->elementGroup = $request->getBodyParam('elementGroup', $feed->elementGroup);

--- a/src/helpers/HttpHelper.php
+++ b/src/helpers/HttpHelper.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace craft\feedme\helpers;
+
+class HttpHelper
+{
+    public static function validate_headers($raw_headers)
+    {
+        return !!preg_match("/^([a-zA-Z0-9-]+:\s*.+\r?\n)*([a-zA-Z0-9-]+:\s*.+)$/", $raw_headers);
+    }
+
+    public static function parse_headers($raw_headers)
+    {
+        $headers = [];
+        $lines = explode("\n", $raw_headers);
+
+        $last_key = null;
+        foreach($lines as $header) {
+            [$key, $value] = explode(':', $header, 2);
+
+            if (!empty($value)) {
+                if (!isset($headers[$key])) {
+                    $headers[$key] = trim($value);
+                } elseif (is_array($headers[$key])) {
+                    $headers[$key] = [...$headers[$key], trim($value)];
+                } else {
+                    $headers[$key] = [$headers[$key], trim($value)];
+                }
+
+                $last_key = $key;
+            } else {
+                if (str_starts_with($key, "\t")) {
+                    $headers[$last_key] .= "\r\n\t".trim($key);
+                }
+            }
+        }
+
+        return $headers;
+    }
+}

--- a/src/migrations/m240209_152309_add_method_and_payload_to_feed.php
+++ b/src/migrations/m240209_152309_add_method_and_payload_to_feed.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace craft\feedme\migrations;
+
+use Craft;
+use craft\db\Migration;
+
+/**
+ * m240209_152309_add_method_and_payload_to_feed migration.
+ */
+class m240209_152309_add_method_and_payload_to_feed extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        if (!$this->db->columnExists('{{%feedme_feeds}}', 'feedMethod')) {
+            $this->addColumn('{{%feedme_feeds}}', 'feedMethod', $this->string()->notNull()->defaultValue('GET')->after('feedType'));
+        }
+
+        if (!$this->db->columnExists('{{%feedme_feeds}}', 'feedHeaders')) {
+            $this->addColumn('{{%feedme_feeds}}', 'feedHeaders', $this->text()->after('feedMethod'));
+        }
+
+        if (!$this->db->columnExists('{{%feedme_feeds}}', 'feedPayload')) {
+            $this->addColumn('{{%feedme_feeds}}', 'feedPayload', $this->text()->after('feedHeaders'));
+        }
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        if ($this->db->columnExists('{{%feedme_feeds}}', 'feedMethod')) {
+            $this->dropColumn('{{%feedme_feeds}}', 'feedMethod');
+        }
+
+        if ($this->db->columnExists('{{%feedme_feeds}}', 'feedHeaders')) {
+            $this->dropColumn('{{%feedme_feeds}}', 'feedHeaders');
+        }
+
+        if ($this->db->columnExists('{{%feedme_feeds}}', 'feedPayload')) {
+            $this->dropColumn('{{%feedme_feeds}}', 'feedPayload');
+        }
+
+        return true;
+    }
+}

--- a/src/models/FeedModel.php
+++ b/src/models/FeedModel.php
@@ -9,6 +9,7 @@ use craft\base\Model;
 use craft\feedme\base\Element;
 use craft\feedme\base\ElementInterface;
 use craft\feedme\helpers\DuplicateHelper;
+use craft\feedme\helpers\HttpHelper;
 use craft\feedme\Plugin;
 use DateTime;
 
@@ -44,6 +45,21 @@ class FeedModel extends Model
      * @var string|null
      */
     public ?string $feedType = null;
+
+    /**
+     * @var string|null
+     */
+    public ?string $feedMethod = null;
+
+    /**
+     * @var string|null
+     */
+    public ?string $feedHeaders = null;
+
+    /**
+     * @var string|null
+     */
+    public ?string $feedPayload = null;
 
     /**
      * @var string|null
@@ -250,8 +266,16 @@ class FeedModel extends Model
     public function rules(): array
     {
         return [
-            [['name', 'feedUrl', 'feedType', 'elementType', 'duplicateHandle', 'passkey'], 'required'],
+            [['name', 'feedUrl', 'feedType', 'feedMethod', 'elementType', 'duplicateHandle', 'passkey'], 'required'],
             [['backup', 'setEmptyValues'], 'boolean'],
+            [['feedHeaders'], 'validateHeaders']
         ];
+    }
+
+    public function validateHeaders($attribute, $params, $validator)
+    {
+        if (!HttpHelper::validate_headers($this->$attribute)) {
+            $this->addError($attribute, Craft::t('feed-me', 'Wrong headers format.'));
+        }
     }
 }

--- a/src/services/DataTypes.php
+++ b/src/services/DataTypes.php
@@ -22,6 +22,7 @@ use craft\feedme\Plugin;
 use craft\helpers\Component as ComponentHelper;
 use Exception;
 use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\RequestOptions;
 use yii\base\Event;
 use yii\base\InvalidConfigException;
 
@@ -207,8 +208,19 @@ class DataTypes extends Component
         try {
             $client = Plugin::$plugin->service->createGuzzleClient($feedId);
             $options = Plugin::$plugin->service->getRequestOptions($feedId);
+            $method = Plugin::$plugin->service->getRequestMethod($feedId);
+            $headers = Plugin::$plugin->service->getRequestHeaders($feedId);
+            $body = Plugin::$plugin->service->getRequestBody($feedId);
 
-            $resp = $client->request('GET', $url, $options);
+            if (!empty($headers)) {
+                $options[RequestOptions::HEADERS] = $headers;
+            }
+
+            if (!empty($body)) {
+                $options[RequestOptions::BODY] = $body;
+            }
+
+            $resp = $client->request($method, $url, $options);
             $data = (string)$resp->getBody();
 
             // Save headers for later

--- a/src/services/Feeds.php
+++ b/src/services/Feeds.php
@@ -122,6 +122,9 @@ class Feeds extends Component
         $record->name = $model->name;
         $record->feedUrl = $model->feedUrl;
         $record->feedType = $model->feedType;
+        $record->feedMethod = $model->feedMethod;
+        $record->feedHeaders = $model->feedHeaders;
+        $record->feedPayload = $model->feedPayload;
         $record->primaryElement = $model->primaryElement;
         $record->elementType = $model->elementType;
         $record->siteId = $model->siteId;
@@ -252,6 +255,9 @@ class Feeds extends Component
                 'name',
                 'feedUrl',
                 'feedType',
+                'feedMethod',
+                'feedHeaders',
+                'feedPayload',
                 'primaryElement',
                 'elementType',
                 'elementGroup',

--- a/src/services/Service.php
+++ b/src/services/Service.php
@@ -6,6 +6,7 @@ use ArrayAccess;
 use Cake\Utility\Hash;
 use Craft;
 use craft\base\Component;
+use craft\feedme\helpers\HttpHelper;
 use craft\feedme\Plugin;
 use craft\helpers\DateTimeHelper;
 use DateTime;
@@ -58,6 +59,36 @@ class Service extends Component
     public function getRequestOptions($feedId = null): mixed
     {
         return $this->getConfig('requestOptions', $feedId);
+    }
+
+    public function getRequestMethod($feedId = null): string
+    {
+        if ($feedId) {
+            $feed = Plugin::$plugin->feeds->getFeedById($feedId);
+            return Hash::get($feed, 'feedMethod', 'GET');
+        }
+
+        return 'GET';
+    }
+
+    public function getRequestHeaders($feedId = null): mixed
+    {
+        if ($feedId) {
+            $feed = Plugin::$plugin->feeds->getFeedById($feedId);
+            return HttpHelper::parse_headers(Hash::get($feed, 'feedHeaders'));
+        }
+
+        return null;
+    }
+
+    public function getRequestBody($feedId = null): ?string
+    {
+        if ($feedId) {
+            $feed = Plugin::$plugin->feeds->getFeedById($feedId);
+            return Hash::get($feed, 'feedPayload');
+        }
+
+        return null;
     }
 
     /**

--- a/src/templates/feeds/_edit.html
+++ b/src/templates/feeds/_edit.html
@@ -71,6 +71,40 @@
         required: true,
     }) }}
 
+    {{ forms.selectField({
+        label: "Request Method"|t('feed-me'),
+        instructions: 'Choose the HTTP Request method to use.'|t('feed-me'),
+        id: 'feedMethod',
+        name: 'feedMethod',
+        options: {
+            GET: 'GET',
+            POST: 'POST'
+        },
+        value: feed.feedMethod ?? 'GET',
+        errors: feed.getErrors('feedMethod'),
+        required: true,
+    }) }}
+
+    {{ forms.textareaField({
+        label: "Request Headers"|t('feed-me'),
+        instructions: 'Customize headers of the HTTP Request if needed.'|t('feed-me'),
+        id: 'feedHeaders',
+        name: 'feedHeaders',
+        rows: 5,
+        value: feed.feedHeaders ?? '',
+        errors: feed.getErrors('feedHeaders'),
+    }) }}
+
+    {{ forms.textareaField({
+        label: "Request Payload"|t('feed-me'),
+        instructions: 'Pass a string body content to the HTTP Request if needed.'|t('feed-me'),
+        id: 'feedPayload',
+        name: 'feedPayload',
+        rows: 10,
+        value: feed.feedPayload ?? '',
+        errors: feed.getErrors('feedPayload'),
+    }) }}
+
     <hr>
 
     {% set elementsList = [] %}
@@ -221,3 +255,26 @@
 {% block footerButton %}
     {{ buttons }}
 {% endblock %}
+
+{#
+https://swapi-graphql.netlify.app/.netlify/functions/index
+
+{"query":"
+query ExampleQuery {
+    allPeople {
+        people {
+            name
+            birthYear
+            height
+            mass
+            species {
+                name
+            }
+            homeworld {
+                name
+            }
+        }
+    }
+}"}
+
+#}


### PR DESCRIPTION
## 📖 Description

Due to the lack of customization for the request of a feed, it wasn't able to fetch data from a GraphQL endpoint for example.

This PR adds three field in a Feed settings to specify the HTTP method, headers and body.

## Results 

<img width="1334" alt="image" src="https://github.com/mirego/craftcms-plugin-feed-me/assets/6747215/2eb9f777-3966-44fd-89de-868f14c6bcb6">

